### PR TITLE
Add Dokku plugin installation and monorepo build-dir support

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,4 +1,11 @@
 version: '3'
+
+includes:
+  claude:
+    taskfile: ~/dev/Taskfile.yml
+    flatten: true
+
+
 tasks:
   doc:
     desc: Generate documentation and inject into README.md after special tags

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -9,6 +9,6 @@ resource "cloudflare_ruleset" "allow_only_allowed_ips" {
     action      = "block"
     description = "Block when the IP address is not in allowed_ips"
     enabled     = true
-    expression  = "not (ip.src in {${join(",", var.allowed_ips)}})"
+    expression  = "not (ip.src in {${join(" ", var.allowed_ips)}})"
   }]
 }

--- a/main.tf
+++ b/main.tf
@@ -77,13 +77,16 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
 
   source_raw {
     data = templatefile("${path.module}/templates/user-data.tftpl.yaml", {
-      hostname       = var.name
-      ssh_public_key = var.ssh_public_key
-      dokku_version  = var.dokku_version
+      hostname             = var.name
+      ssh_public_key       = var.ssh_public_key
+      dokku_version        = var.dokku_version
+      install_plugins      = var.install_plugins
+      enable_monorepo_hook = var.enable_monorepo_hook
     })
     file_name = "user-data.${var.name}.yaml"
   }
 }
+
 
 resource "proxmox_virtual_environment_file" "dokku_wait_hook" {
   content_type = "snippets"

--- a/templates/user-data.tftpl.yaml
+++ b/templates/user-data.tftpl.yaml
@@ -30,6 +30,14 @@ write_files:
       #!/bin/bash
       set -eux
 
+      # Verify qemu-guest-agent is running
+      if ! systemctl is-active --quiet qemu-guest-agent; then
+        echo "ERROR: qemu-guest-agent is not running"
+        systemctl status qemu-guest-agent || true
+        exit 1
+      fi
+      echo "qemu-guest-agent is running"
+
       # Add Docker GPG key
       mkdir -p /etc/apt/keyrings
       curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -44,8 +52,81 @@ write_files:
       wget https://raw.githubusercontent.com/dokku/dokku/v${dokku_version}/bootstrap.sh
       DOKKU_TAG=v${dokku_version} bash bootstrap.sh
       cat ~/.ssh/authorized_keys | dokku ssh-keys:add admin
+%{ for plugin in install_plugins ~}
+      dokku plugin:install ${plugin}
+%{ endfor ~}
+%{ if enable_monorepo_hook ~}
+      dokku plugin:enable build-dir-dockerfile 2>/dev/null || true
+%{ endif ~}
+%{ if enable_monorepo_hook ~}
+  - path: /var/lib/dokku/plugins/available/build-dir-dockerfile/post-extract
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env bash
+      set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+      source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+      source "$PLUGIN_CORE_AVAILABLE_PATH/common/property-functions"
+
+      APP="$1"; TMP_WORK_DIR="$2"; REV="$3"
+
+      dokku_log_info1 "build-dir-dockerfile: post-extract hook running for app '$APP'"
+
+      # Get the build-dir property for this app
+      BUILD_DIR="$(fn-plugin-property-get "builder" "$APP" "build-dir" "")"
+
+      if [[ -z "$BUILD_DIR" ]]; then
+        dokku_log_info1 "build-dir-dockerfile: no build-dir set for app '$APP', skipping"
+        exit 0
+      fi
+
+      dokku_log_info1 "build-dir-dockerfile: build-dir is '$BUILD_DIR'"
+      dokku_log_info1 "build-dir-dockerfile: git revision is '$REV'"
+
+      # Debug: Show what's in the worktree
+      dokku_log_info1 "build-dir-dockerfile: DEBUG - current directory: $(pwd)"
+      dokku_log_info1 "build-dir-dockerfile: DEBUG - TMP_WORK_DIR: $TMP_WORK_DIR"
+      dokku_log_info1 "build-dir-dockerfile: DEBUG - contents of TMP_WORK_DIR:"
+      ls -la "$TMP_WORK_DIR" 2>&1 | while read line; do dokku_log_info1 "  $line"; done
+
+      if [[ -d "$TMP_WORK_DIR/apps" ]]; then
+        dokku_log_info1 "build-dir-dockerfile: DEBUG - contents of apps/:"
+        ls -la "$TMP_WORK_DIR/apps" 2>&1 | while read line; do dokku_log_info1 "  $line"; done
+      else
+        dokku_log_warn "build-dir-dockerfile: DEBUG - apps/ directory does not exist"
+      fi
+
+      if [[ -d "$TMP_WORK_DIR/apps/n8n" ]]; then
+        dokku_log_info1 "build-dir-dockerfile: DEBUG - contents of apps/n8n/:"
+        ls -la "$TMP_WORK_DIR/apps/n8n" 2>&1 | while read line; do dokku_log_info1 "  $line"; done
+      else
+        dokku_log_warn "build-dir-dockerfile: DEBUG - apps/n8n/ directory does not exist"
+      fi
+
+      if [[ ! -f "$TMP_WORK_DIR/$BUILD_DIR/Dockerfile" ]]; then
+        dokku_log_warn "build-dir-dockerfile: Dockerfile not found at '$BUILD_DIR/Dockerfile'"
+        exit 1
+      fi
+
+      dokku_log_info1 "build-dir-dockerfile: copying Dockerfile from '$BUILD_DIR/'"
+      cp -f "$TMP_WORK_DIR/$BUILD_DIR/Dockerfile" "$TMP_WORK_DIR/Dockerfile"
+
+      # Also copy .dockerignore if it exists
+      if [[ -f "$TMP_WORK_DIR/$BUILD_DIR/.dockerignore" ]]; then
+        dokku_log_info1 "build-dir-dockerfile: copying .dockerignore from '$BUILD_DIR/'"
+        cp -f "$TMP_WORK_DIR/$BUILD_DIR/.dockerignore" "$TMP_WORK_DIR/.dockerignore"
+      fi
+
+      dokku_log_info1 "build-dir-dockerfile: post-extract complete"
+  - path: /var/lib/dokku/plugins/available/build-dir-dockerfile/plugin.toml
+    permissions: '0644'
+    content: |
+      [plugin]
+      description = "dokku build-dir-dockerfile plugin - supports Dockerfile in build-dir for monorepos"
+      version = "0.1.0"
+      [plugin.config]
+%{ endif ~}
 
 runcmd:
   - systemctl start qemu-guest-agent
-  - systemctl enable qemu-guest-agent
-  - (/root/init.sh && touch /root/.bootstrap-done || /root/.bootstrap-failed) > /var/log/init.log 2>&1
+  - sleep 5
+  - (/root/init.sh && touch /root/.bootstrap-done || touch /root/.bootstrap-failed) > /var/log/init.log 2>&1

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,15 @@ variable "image" {
     checksum = "c651c2f3fd1ee342f225724959a86a97ad804027c3f057e03189455d093d07a006390929a22df0f95a5269291badc619964bde8bf9e2a33b6f3a01f492895068"
   }
 }
+
+variable "install_plugins" {
+  description = "List of Dokku plugins to install."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_monorepo_hook" {
+  description = "Enable custom post-extract hook to support Dockerfile in build-dir for monorepos."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Changes
- chore(user-data): verify qemu-guest-agent is running in user data script
- chore(user-data): add Dokku plugin installation loop and enable build-dir-dockerfile plugin optionally
- chore(user-data): add custom post-extract hook script for build-dir Dockerfile support with debug logs
- chore(user-data): add plugin.toml descriptor for build-dir-dockerfile plugin
- chore(user-data): delay init.sh execution by 5s and fix flag touch on failure
- chore(main): pass install_plugins and enable_monorepo_hook variables to user-data template
- chore(variables): add install_plugins list and enable_monorepo_hook bool variables
- chore(Taskfile): include external Taskfile from ~/dev/Taskfile.yml for claude tasks
- fix(cloudflare): correct Cloudflare IP set join separator from comma to space