### PR TITLE
Add Cloudflare Tunnel support & Mounts for Dokku VM deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ module "dokku_node" {
 }
 ```
 
+### With NFS Mount
+
+```hcl
+module "dokku_node" {
+  source           = "dimmkirr/dokku-proxmox/terraform"
+  version          = "~> 0.1"
+  name             = "dokku-app"
+  root_domain      = "example.com"
+  mac_address      = "AA:BB:CC:DD:EE:FF"
+  ssh_public_key   = file("~/.ssh/id_rsa.pub")
+
+  mounts = [
+    {
+      device  = "192.168.1.100:/mnt/storage/dokku-data"
+      path    = "/mnt/dokku-data"
+      fstype  = "nfs4"
+      options = "rw,hard,intr,_netdev"
+    }
+  ]
+}
+```
+
 > **Note:** This module currently provisions only Debian 12 VMs.
 
 For a complete example, see [`examples/complete`](./examples/complete/).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,29 @@ For a complete example, see [`examples/complete`](./examples/complete/).
 ## Requirements
 - [Terraform](https://www.terraform.io/downloads.html) or [OpenTofu](https://opentofu.org/download/)
 - Proxmox access
-- Cloudflare API token
+- Cloudflare API token with the following permissions:
+
+### Cloudflare API Token Permissions
+
+> **Note:** These permissions are known to work. They can likely be refined to Edit/Read instead of all Edit for tighter security.
+
+**All accounts:**
+- DNS Settings: Edit
+- Cloudflare One Connector: cloudflared: Edit
+- Cloudflare Pages: Edit
+- Transform Rules: Edit
+- Account Rulesets: Edit
+- Cloudflare Tunnel: Edit
+- Rule Policies: Edit
+- Zero Trust: Edit
+- Account Settings: Edit
+
+**All zones:**
+- Zone Settings: Edit
+- SSL and Certificates: Edit
+- Page Rules: Edit
+- Firewall Services: Edit
+- DNS: Edit
 
 ## Getting Started
 1. Clone this repo or use as a module source.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ For a complete example, see [`examples/complete`](./examples/complete/).
 |------|---------|
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | 5.6.0 |
 | <a name="requirement_proxmox"></a> [proxmox](#requirement\_proxmox) | >= 0.50.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.6.0 |
-| <a name="provider_proxmox"></a> [proxmox](#provider\_proxmox) | >= 0.50.0 |
+| <a name="provider_proxmox"></a> [proxmox](#provider\_proxmox) | 0.87.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
 
 ## Modules
 
@@ -68,35 +70,50 @@ No modules.
 | Name | Type |
 |------|------|
 | [cloudflare_ruleset.allow_only_allowed_ips](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/resources/ruleset) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/resources/zero_trust_tunnel_cloudflared) | resource |
+| [cloudflare_zero_trust_tunnel_cloudflared_config.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/resources/zero_trust_tunnel_cloudflared_config) | resource |
 | [proxmox_virtual_environment_download_file.image](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_download_file) | resource |
 | [proxmox_virtual_environment_file.cloud_config](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_file) | resource |
 | [proxmox_virtual_environment_file.dokku_wait_hook](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_file) | resource |
 | [proxmox_virtual_environment_vm.this](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm) | resource |
+| [random_password.tunnel_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [cloudflare_ip_ranges.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/data-sources/ip_ranges) | data source |
+| [cloudflare_zero_trust_tunnel_cloudflared.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/data-sources/zero_trust_tunnel_cloudflared) | data source |
+| [cloudflare_zero_trust_tunnel_cloudflared_token.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/data-sources/zero_trust_tunnel_cloudflared_token) | data source |
 | [cloudflare_zone.this](https://registry.terraform.io/providers/cloudflare/cloudflare/5.6.0/docs/data-sources/zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | n/a | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
-| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | n/a | `number` | `"50"` | no |
-| <a name="input_dokku_version"></a> [dokku\_version](#input\_dokku\_version) | n/a | `string` | `"0.34.7"` | no |
-| <a name="input_iso_storage"></a> [iso\_storage](#input\_iso\_storage) | n/a | `string` | `"local"` | no |
-| <a name="input_mac_address"></a> [mac\_address](#input\_mac\_address) | n/a | `string` | n/a | yes |
-| <a name="input_manage_cloudflare"></a> [manage\_cloudflare](#input\_manage\_cloudflare) | Enable Cloudflare DNS record management | `bool` | `true` | no |
-| <a name="input_name"></a> [name](#input\_name) | n/a | `any` | n/a | yes |
-| <a name="input_root_domain"></a> [root\_domain](#input\_root\_domain) | n/a | `any` | n/a | yes |
-| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH public key contents | `string` | n/a | yes |
-| <a name="input_target_node"></a> [target\_node](#input\_target\_node) | n/a | `string` | `"pve"` | no |
-| <a name="input_vm_id"></a> [vm\_id](#input\_vm\_id) | n/a | `any` | `null` | no |
-| <a name="input_vm_storage"></a> [vm\_storage](#input\_vm\_storage) | n/a | `string` | `"local-lvm"` | no |
+| <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | List of allowed IPs for Cloudflare rules. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_cloudflare_account_id"></a> [cloudflare\_account\_id](#input\_cloudflare\_account\_id) | Cloudflare account ID for tunnel management | `string` | `""` | no |
+| <a name="input_cloudflare_tunnel_enabled"></a> [cloudflare\_tunnel\_enabled](#input\_cloudflare\_tunnel\_enabled) | Enable Cloudflare Tunnel integration | `bool` | `true` | no |
+| <a name="input_cloudflare_tunnel_name"></a> [cloudflare\_tunnel\_name](#input\_cloudflare\_tunnel\_name) | Name of the Cloudflare tunnel (created or referenced). Defaults to var.name if empty. | `string` | `""` | no |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | VM disk size in GB. | `number` | `"50"` | no |
+| <a name="input_dokku_version"></a> [dokku\_version](#input\_dokku\_version) | Dokku version to install. | `string` | `"0.34.7"` | no |
+| <a name="input_enable_monorepo_hook"></a> [enable\_monorepo\_hook](#input\_enable\_monorepo\_hook) | Enable custom post-extract hook to support Dockerfile in build-dir for monorepos. | `bool` | `false` | no |
+| <a name="input_image"></a> [image](#input\_image) | n/a | `map(string)` | <pre>{<br/>  "checksum": "c651c2f3fd1ee342f225724959a86a97ad804027c3f057e03189455d093d07a006390929a22df0f95a5269291badc619964bde8bf9e2a33b6f3a01f492895068",<br/>  "checksum_algorithm": "sha512",<br/>  "file_name": "debian-12-generic-amd64.img",<br/>  "url": "https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2"<br/>}</pre> | no |
+| <a name="input_install_plugins"></a> [install\_plugins](#input\_install\_plugins) | List of Dokku plugins to install. | `list(string)` | `[]` | no |
+| <a name="input_iso_storage"></a> [iso\_storage](#input\_iso\_storage) | Proxmox storage backend for ISO/snippet files. | `string` | `"local"` | no |
+| <a name="input_mac_address"></a> [mac\_address](#input\_mac\_address) | MAC address for the VM network interface. | `string` | n/a | yes |
+| <a name="input_manage_cloudflare"></a> [manage\_cloudflare](#input\_manage\_cloudflare) | Enable Cloudflare DNS record management. | `bool` | `true` | no |
+| <a name="input_manage_cloudflare_tunnel"></a> [manage\_cloudflare\_tunnel](#input\_manage\_cloudflare\_tunnel) | Create a new Cloudflare tunnel (true) or reference existing (false) | `bool` | `true` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Dokku VM and related resources. | `any` | n/a | yes |
+| <a name="input_root_domain"></a> [root\_domain](#input\_root\_domain) | Root domain for DNS records (e.g., example.com). | `any` | n/a | yes |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | SSH public key contents. | `string` | n/a | yes |
+| <a name="input_target_node"></a> [target\_node](#input\_target\_node) | Proxmox node name where the VM will be created. | `string` | `"pve"` | no |
+| <a name="input_vm_id"></a> [vm\_id](#input\_vm\_id) | Optional static VM ID. If not set, Proxmox auto-assigns. | `any` | `null` | no |
+| <a name="input_vm_storage"></a> [vm\_storage](#input\_vm\_storage) | Proxmox storage backend for the VM disk. | `string` | `"local-lvm"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_allowed_ips"></a> [allowed\_ips](#output\_allowed\_ips) | n/a |
+| <a name="output_cloudflare_tunnel_cname"></a> [cloudflare\_tunnel\_cname](#output\_cloudflare\_tunnel\_cname) | CNAME target for DNS records pointing to this tunnel |
+| <a name="output_cloudflare_tunnel_id"></a> [cloudflare\_tunnel\_id](#output\_cloudflare\_tunnel\_id) | Cloudflare tunnel ID (connector ID) |
+| <a name="output_cloudflare_tunnel_name"></a> [cloudflare\_tunnel\_name](#output\_cloudflare\_tunnel\_name) | Cloudflare tunnel name |
 | <a name="output_ipv4_address"></a> [ipv4\_address](#output\_ipv4\_address) | n/a |
 | <a name="output_username"></a> [username](#output\_username) | n/a |
 <!-- END_TF_DOCS -->

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -12,3 +12,66 @@ resource "cloudflare_ruleset" "allow_only_allowed_ips" {
     expression  = "not (ip.src in {${join(" ", var.allowed_ips)}})"
   }]
 }
+
+# Locals for unified tunnel access (managed vs referenced)
+locals {
+  tunnel_id = var.cloudflare_tunnel_enabled ? (
+    var.manage_cloudflare_tunnel ? cloudflare_zero_trust_tunnel_cloudflared.this[0].id : data.cloudflare_zero_trust_tunnel_cloudflared.this[0].id
+  ) : ""
+
+  tunnel_name = var.cloudflare_tunnel_enabled ? (
+    var.manage_cloudflare_tunnel ? cloudflare_zero_trust_tunnel_cloudflared.this[0].name : data.cloudflare_zero_trust_tunnel_cloudflared.this[0].name
+  ) : ""
+
+  effective_tunnel_name = var.cloudflare_tunnel_name != "" ? var.cloudflare_tunnel_name : var.name
+}
+
+# Random secret for managed tunnel
+resource "random_password" "tunnel_secret" {
+  count   = var.cloudflare_tunnel_enabled && var.manage_cloudflare_tunnel ? 1 : 0
+  length  = 64
+  special = false
+}
+
+# Managed tunnel (create new)
+resource "cloudflare_zero_trust_tunnel_cloudflared" "this" {
+  count         = var.cloudflare_tunnel_enabled && var.manage_cloudflare_tunnel ? 1 : 0
+  account_id    = var.cloudflare_account_id
+  name          = local.effective_tunnel_name
+  tunnel_secret = base64encode(random_password.tunnel_secret[0].result)
+}
+
+# Referenced tunnel (use existing)
+data "cloudflare_zero_trust_tunnel_cloudflared" "this" {
+  count      = var.cloudflare_tunnel_enabled && !var.manage_cloudflare_tunnel ? 1 : 0
+  account_id = var.cloudflare_account_id
+  filter = {
+    name = local.effective_tunnel_name
+  }
+}
+
+# Tunnel configuration with ingress rules
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
+  count      = var.cloudflare_tunnel_enabled ? 1 : 0
+  account_id = var.cloudflare_account_id
+  tunnel_id  = local.tunnel_id
+
+  config = {
+    ingress = [
+      # Root domain ingress
+      {
+        hostname = var.root_domain
+        service  = "http://localhost:80"
+      },
+      # Wildcard subdomain ingress
+      {
+        hostname = "*.${var.root_domain}"
+        service  = "http://localhost:80"
+      },
+      # Catch-all (required by Cloudflare)
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -30,7 +30,7 @@ locals {
     var.manage_cloudflare_tunnel ? cloudflare_zero_trust_tunnel_cloudflared.this[0].name : data.cloudflare_zero_trust_tunnel_cloudflared.this[0].name
   ) : ""
 
-  effective_tunnel_name = var.cloudflare_tunnel_name != "" ? var.cloudflare_tunnel_name : var.name
+  effective_tunnel_name = var.cloudflare_tunnel_name != "" ? var.cloudflare_tunnel_name : "${var.name}.${var.root_domain}"
 }
 
 # Random secret for managed tunnel

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -15,6 +15,13 @@ resource "cloudflare_ruleset" "allow_only_allowed_ips" {
 
 # Locals for unified tunnel access (managed vs referenced)
 locals {
+  # Auto-detect account_id from API token if not explicitly provided
+  cloudflare_account_id = var.cloudflare_account_id != "" ? var.cloudflare_account_id : (
+    length(data.cloudflare_accounts.this) > 0 && length(data.cloudflare_accounts.this[0].result) > 0
+    ? data.cloudflare_accounts.this[0].result[0].id
+    : ""
+  )
+
   tunnel_id = var.cloudflare_tunnel_enabled ? (
     var.manage_cloudflare_tunnel ? cloudflare_zero_trust_tunnel_cloudflared.this[0].id : data.cloudflare_zero_trust_tunnel_cloudflared.this[0].id
   ) : ""
@@ -36,15 +43,30 @@ resource "random_password" "tunnel_secret" {
 # Managed tunnel (create new)
 resource "cloudflare_zero_trust_tunnel_cloudflared" "this" {
   count         = var.cloudflare_tunnel_enabled && var.manage_cloudflare_tunnel ? 1 : 0
-  account_id    = var.cloudflare_account_id
+  account_id    = local.cloudflare_account_id
   name          = local.effective_tunnel_name
   tunnel_secret = base64encode(random_password.tunnel_secret[0].result)
+
+  lifecycle {
+    precondition {
+      condition     = local.cloudflare_account_id != ""
+      error_message = <<-EOT
+        Cloudflare account ID could not be auto-detected from API token.
+
+        This usually means your API token doesn't have account-level permissions.
+
+        Please set var.cloudflare_account_id explicitly:
+        - Find your account ID in Cloudflare dashboard → Account Settings → Account ID
+        - Or grant your API token "Account" permissions
+      EOT
+    }
+  }
 }
 
 # Referenced tunnel (use existing)
 data "cloudflare_zero_trust_tunnel_cloudflared" "this" {
   count      = var.cloudflare_tunnel_enabled && !var.manage_cloudflare_tunnel ? 1 : 0
-  account_id = var.cloudflare_account_id
+  account_id = local.cloudflare_account_id
   filter = {
     name = local.effective_tunnel_name
   }
@@ -53,7 +75,7 @@ data "cloudflare_zero_trust_tunnel_cloudflared" "this" {
 # Tunnel configuration with ingress rules
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
   count      = var.cloudflare_tunnel_enabled ? 1 : 0
-  account_id = var.cloudflare_account_id
+  account_id = local.cloudflare_account_id
   tunnel_id  = local.tunnel_id
 
   config = {

--- a/data.tf
+++ b/data.tf
@@ -7,3 +7,10 @@ data "cloudflare_zone" "this" {
 data "cloudflare_ip_ranges" "this" {
   networks = "networks"
 }
+
+# Tunnel token for connector authentication
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "this" {
+  count      = var.cloudflare_tunnel_enabled ? 1 : 0
+  account_id = var.cloudflare_account_id
+  tunnel_id  = local.tunnel_id
+}

--- a/data.tf
+++ b/data.tf
@@ -8,9 +8,15 @@ data "cloudflare_ip_ranges" "this" {
   networks = "networks"
 }
 
+# Auto-detect Cloudflare account ID from API token if not explicitly provided
+# Fetches ALL accounts the token has access to (no filters)
+data "cloudflare_accounts" "this" {
+  count = var.cloudflare_tunnel_enabled && var.cloudflare_account_id == "" ? 1 : 0
+}
+
 # Tunnel token for connector authentication
 data "cloudflare_zero_trust_tunnel_cloudflared_token" "this" {
   count      = var.cloudflare_tunnel_enabled ? 1 : 0
-  account_id = var.cloudflare_account_id
+  account_id = local.cloudflare_account_id
   tunnel_id  = local.tunnel_id
 }

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
       enable_monorepo_hook      = var.enable_monorepo_hook
       cloudflare_tunnel_enabled = var.cloudflare_tunnel_enabled
       cloudflare_tunnel_token   = var.cloudflare_tunnel_enabled ? data.cloudflare_zero_trust_tunnel_cloudflared_token.this[0].token : ""
+      mounts                    = var.mounts
     })
     file_name = "user-data.${var.name}.yaml"
   }

--- a/main.tf
+++ b/main.tf
@@ -77,11 +77,13 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
 
   source_raw {
     data = templatefile("${path.module}/templates/user-data.tftpl.yaml", {
-      hostname             = var.name
-      ssh_public_key       = var.ssh_public_key
-      dokku_version        = var.dokku_version
-      install_plugins      = var.install_plugins
-      enable_monorepo_hook = var.enable_monorepo_hook
+      hostname                  = var.name
+      ssh_public_key            = var.ssh_public_key
+      dokku_version             = var.dokku_version
+      install_plugins           = var.install_plugins
+      enable_monorepo_hook      = var.enable_monorepo_hook
+      cloudflare_tunnel_enabled = var.cloudflare_tunnel_enabled
+      cloudflare_tunnel_token   = var.cloudflare_tunnel_enabled ? data.cloudflare_zero_trust_tunnel_cloudflared_token.this[0].token : ""
     })
     file_name = "user-data.${var.name}.yaml"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,3 +15,19 @@ locals {
   non_local_ips = [for ip in local.all_ips : ip if ip != "127.0.0.1"]
 }
 
+# Cloudflare Tunnel outputs
+output "cloudflare_tunnel_name" {
+  description = "Cloudflare tunnel name"
+  value       = var.cloudflare_tunnel_enabled ? local.tunnel_name : null
+}
+
+output "cloudflare_tunnel_id" {
+  description = "Cloudflare tunnel ID (connector ID)"
+  value       = var.cloudflare_tunnel_enabled ? local.tunnel_id : null
+}
+
+output "cloudflare_tunnel_cname" {
+  description = "CNAME target for DNS records pointing to this tunnel"
+  value       = var.cloudflare_tunnel_enabled ? "${local.tunnel_id}.cfargotunnel.com" : null
+}
+

--- a/templates/user-data.tftpl.yaml
+++ b/templates/user-data.tftpl.yaml
@@ -58,6 +58,20 @@ write_files:
 %{ if enable_monorepo_hook ~}
       dokku plugin:enable build-dir-dockerfile 2>/dev/null || true
 %{ endif ~}
+%{ if cloudflare_tunnel_enabled ~}
+
+      # Install and configure Cloudflare Tunnel connector
+      echo "Installing cloudflared..."
+      curl -L --output /tmp/cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+      dpkg -i /tmp/cloudflared.deb
+      rm /tmp/cloudflared.deb
+
+      # Install tunnel as a service using the token
+      cloudflared service install ${cloudflare_tunnel_token}
+      systemctl enable cloudflared
+      systemctl start cloudflared
+      echo "Cloudflared installed and started"
+%{ endif ~}
 %{ if enable_monorepo_hook ~}
   - path: /var/lib/dokku/plugins/available/build-dir-dockerfile/post-extract
     permissions: '0755'

--- a/templates/user-data.tftpl.yaml
+++ b/templates/user-data.tftpl.yaml
@@ -2,6 +2,12 @@
 hostname: ${hostname}
 package_update: true
 package_upgrade: true
+%{ if length(mounts) > 0 ~}
+mounts:
+%{ for mount in mounts ~}
+  - [ "${mount.device}", "${mount.path}", "${mount.fstype}", "${mount.options}", "${mount.dump}", "${mount.pass}" ]
+%{ endfor ~}
+%{ endif ~}
 packages:
   - apt-transport-https
   - ca-certificates

--- a/templates/user-data.tftpl.yaml
+++ b/templates/user-data.tftpl.yaml
@@ -18,6 +18,10 @@ packages:
   - mc
   - htop
   - qemu-guest-agent
+%{ if length(mounts) > 0 ~}
+  - nfs-common
+  - cifs-utils
+%{ endif ~}
 
 users:
   - name: root

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,16 @@ variable "cloudflare_account_id" {
   default     = ""
   sensitive   = true
 }
+
+variable "mounts" {
+  description = "List of filesystem mounts to add to /etc/fstab. Each mount requires device, path, fstype, and options. Dump and pass are optional (default to 0)."
+  type = list(object({
+    device  = string
+    path    = string
+    fstype  = string
+    options = string
+    dump    = optional(string, "0")
+    pass    = optional(string, "0")
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "cloudflare_tunnel_name" {
 }
 
 variable "cloudflare_account_id" {
-  description = "Cloudflare account ID for tunnel management"
+  description = "Cloudflare account ID for tunnel management. Leave empty to auto-detect from API token (works if token has access to only one account)."
   type        = string
   default     = ""
   sensitive   = true

--- a/variables.tf
+++ b/variables.tf
@@ -63,10 +63,10 @@ variable "manage_cloudflare" {
 variable "image" {
   type = map(string)
   default = {
-    file_name = "debian-12-generic-amd64.img"
-    url = "https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2"
+    file_name          = "debian-12-generic-amd64.img"
+    url                = "https://cloud.debian.org/images/cloud/bookworm/20250703-2162/debian-12-generic-amd64-20250703-2162.qcow2"
     checksum_algorithm = "sha512"
-    checksum = "c651c2f3fd1ee342f225724959a86a97ad804027c3f057e03189455d093d07a006390929a22df0f95a5269291badc619964bde8bf9e2a33b6f3a01f492895068"
+    checksum           = "c651c2f3fd1ee342f225724959a86a97ad804027c3f057e03189455d093d07a006390929a22df0f95a5269291badc619964bde8bf9e2a33b6f3a01f492895068"
   }
 }
 
@@ -80,4 +80,29 @@ variable "enable_monorepo_hook" {
   description = "Enable custom post-extract hook to support Dockerfile in build-dir for monorepos."
   type        = bool
   default     = false
+}
+
+variable "cloudflare_tunnel_enabled" {
+  description = "Enable Cloudflare Tunnel integration"
+  type        = bool
+  default     = true
+}
+
+variable "manage_cloudflare_tunnel" {
+  description = "Create a new Cloudflare tunnel (true) or reference existing (false)"
+  type        = bool
+  default     = true
+}
+
+variable "cloudflare_tunnel_name" {
+  description = "Name of the Cloudflare tunnel (created or referenced). Defaults to var.name if empty."
+  type        = string
+  default     = ""
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for tunnel management"
+  type        = string
+  default     = ""
+  sensitive   = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,11 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "5.6.0"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 
 


### PR DESCRIPTION
# Changes
- chore(terraform): add Cloudflare Tunnel resources with managed and referenced modes in cloudflare.tf
- feat(template): install and enable cloudflared service in VM user-data template
- chore(terraform): add cloudflare_zero_trust_tunnel_cloudflared_token data source for tunnel authentication
- chore(terraform): pass cloudflare tunnel enabled flag and token to user-data template in main.tf
- chore(terraform): update versions.tf to include hashicorp/random provider for password generation
- docs(terraform): update README.md with new Cloudflare tunnel resources, data sources, inputs, and outputs
- chore(terraform): add Cloudflare tunnel related variables and outputs to variables.tf and outputs.tf
- chore(gitignore): ignore .worktrees directory